### PR TITLE
create js/bundle directory on demand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+js/bundle

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "bundle": "browserify ./js/index.js -o ./js/bundle/bundle.js"
+    "bundle": "mkdir -p js/bundle && browserify ./js/index.js -o ./js/bundle/bundle.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
When running 'bundle" npm script I got an error because the "bundle" directory does not exists. This way I modified the browserify script this will happen automatically.

Also added a gitignore file since makes no sense to add these to the repo IMO.
